### PR TITLE
Pass error to catch handler if predicate is a function - fixes #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = (predicate, fn) => err => {
 	} else if (typeof predicate === 'function') {
 		return Promise.resolve(err)
 			.then(predicate)
-			.then(val => val === true ? fn() : Promise.reject(err));
+			.then(val => val === true ? fn(err) : Promise.reject(err));
 	}
 
 	throw err;

--- a/test.js
+++ b/test.js
@@ -57,6 +57,13 @@ test('predicate function returns true', async t => {
 	t.is(result, fixture);
 });
 
+test('predicate function that returns true should pass error to catch handler', async t => {
+	const result = await Promise.reject(fixtureErr)
+		.catch(m(() => true, err => err));
+
+	t.is(result, fixtureErr);
+});
+
 test('predicate function returns false', async t => {
 	const result = await Promise.reject(fixtureErr)
 		.catch(m(() => false, () => fixture))


### PR DESCRIPTION
This PR fixes #1 as the error wasn't passed through to the catch handler when the predicate was a function.